### PR TITLE
feat: Adds splash potion projectile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.alathra</groupId>
     <artifactId>SiegeEngines</artifactId>
-    <version>0.7.9</version>
+    <version>0.8.4</version>
 
     <packaging>jar</packaging>
     <name>SiegeEngines</name>

--- a/src/main/java/com/github/alathra/siegeengines/config/Config.java
+++ b/src/main/java/com/github/alathra/siegeengines/config/Config.java
@@ -20,6 +20,7 @@ import com.github.alathra.siegeengines.SiegeEnginesUtil;
 import com.github.alathra.siegeengines.projectile.EntityProjectile;
 import com.github.alathra.siegeengines.projectile.ExplosiveProjectile;
 import com.github.alathra.siegeengines.projectile.FireworkProjectile;
+import com.github.alathra.siegeengines.projectile.PotionProjectile;
 import com.github.alathra.siegeengines.projectile.ProjectileType;
 import com.github.alathra.siegeengines.projectile.SiegeEngineProjectile;
 
@@ -294,6 +295,22 @@ public class Config {
 					fireworkProjectile.velocityFactor = (float) config
 							.getDouble("Projectiles." + projectileName + ".VelocityFactor");
 					projectileMap.put(projectileName, fireworkProjectile);
+					break;
+				case POTION:
+					PotionProjectile potionProjectile = new PotionProjectile(new ItemStack(
+							Material.getMaterial(config.getString("Projectiles." + projectileName + ".AmmoItem"))));
+					potionProjectile.inaccuracy = (float) config
+							.getDouble("Projectiles." + projectileName + ".Inaccuracy");
+					potionProjectile.entityCount = config.getInt("Projectiles." + projectileName + ".EntityCount");
+					potionProjectile.delayTime = config.getInt("Projectiles." + projectileName + ".EntityCount");
+					if (potionProjectile.delayTime <= 0) {
+						potionProjectile.delayedFire = false;
+					} else {
+						potionProjectile.delayedFire = true;
+					}
+					potionProjectile.velocityFactor = (float) config
+							.getDouble("Projectiles." + projectileName + ".VelocityFactor");
+					projectileMap.put(projectileName, potionProjectile);
 					break;
 				default:
 					continue;

--- a/src/main/java/com/github/alathra/siegeengines/listeners/ClickHandler.java
+++ b/src/main/java/com/github/alathra/siegeengines/listeners/ClickHandler.java
@@ -16,6 +16,7 @@ import com.github.alathra.siegeengines.SiegeEnginesUtil;
 import com.github.alathra.siegeengines.SiegeEngine;
 import com.github.alathra.siegeengines.projectile.ExplosiveProjectile;
 import com.github.alathra.siegeengines.projectile.FireworkProjectile;
+import com.github.alathra.siegeengines.projectile.PotionProjectile;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -47,6 +48,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.util.EulerAngle;
 
@@ -272,7 +274,8 @@ public class ClickHandler implements Listener {
 					return true;
 				}
 				inventoryItem = inventoryItem.clone();
-				if (!(stack.isSimilar(inventoryItem)) && (stack.getType() != Material.FIREWORK_ROCKET))
+				if (!(stack.isSimilar(inventoryItem)) && (stack.getType() != Material.FIREWORK_ROCKET)
+						&& (stack.getType() != Material.SPLASH_POTION))
 					continue;
 				inventoryItem.setAmount(1);
 				if (stack.getType() != Material.FIREWORK_ROCKET && stack.isSimilar(inventoryItem)
@@ -288,6 +291,15 @@ public class ClickHandler implements Listener {
 					siegeEngine.getAmmoHolder().setMaterialName(inventoryItem);
 					state.getInventory().removeItem(inventoryItem);
 					FireworkProjectile proj = FireworkProjectile.getDefaultRocketShot(inventoryItem.clone());
+					siegeEngine.getProjectiles().put(inventoryItem, proj);
+					return true;
+				}
+				if (stack.getType() == Material.SPLASH_POTION && inventoryItem.getType() == stack.getType()
+						&& siegeEngine.getAmmoHolder().getLoadedProjectile() == 0) {
+					siegeEngine.getAmmoHolder().setLoadedProjectile(1);
+					siegeEngine.getAmmoHolder().setMaterialName(inventoryItem);
+					state.getInventory().removeItem(inventoryItem);
+					PotionProjectile proj = new PotionProjectile(inventoryItem);
 					siegeEngine.getProjectiles().put(inventoryItem, proj);
 					return true;
 				}

--- a/src/main/java/com/github/alathra/siegeengines/projectile/PotionProjectile.java
+++ b/src/main/java/com/github/alathra/siegeengines/projectile/PotionProjectile.java
@@ -20,24 +20,25 @@ import org.bukkit.util.Vector;
 
 public class PotionProjectile extends SiegeEngineProjectile {
 	
-    public int EntityCount = 3;
-    public Boolean DelayedFire = false;
-    public int DelayTime = 6;
-    public float Inaccuracy = 0.1f;
-    public Particle ParticleType = Particle.EXPLOSION_LARGE;
-    public Sound SoundType = Sound.ENTITY_GENERIC_EXPLODE;
-    
+    public int entityCount = 3;
+    public Boolean delayedFire = false;
+    public int delayTime = 6;
+    public float inaccuracy = 0.1f;
+    public Particle particleType = Particle.EXPLOSION_LARGE;
+    public Sound soundType = Sound.ENTITY_GENERIC_EXPLODE;
+    public float velocityFactor = 1.0f;
+
     public PotionProjectile(ItemStack ammunitionItem) {
 		super(ProjectileType.POTION, ammunitionItem);
 	}
-    
+
     @Override
     public void Shoot(Entity player, Entity entity, Location loc, Float velocity) {
         //TODO Auto-generated method stub
         int baseDelay = 0;
-        for (int i = 0; i < EntityCount; i++) {
-            if (DelayedFire) {
-                baseDelay += DelayTime;
+        for (int i = 0; i < entityCount; i++) {
+            if (delayedFire) {
+                baseDelay += delayTime;
                 Bukkit.getServer().getScheduler().scheduleSyncDelayedTask(SiegeEngines.getInstance(), () -> {
 
                     CreateEntity(entity, loc, velocity);
@@ -52,25 +53,27 @@ public class PotionProjectile extends SiegeEngineProjectile {
         World world = entity.getLocation().getWorld();
 
         Entity arrow = world.spawnEntity(loc, EntityType.SPLASH_POTION);
-        if (Inaccuracy != 0f) {
+        if (inaccuracy != 0f) {
             arrow.setVelocity(loc.getDirection().multiply(velocity).add(Randomise()).subtract(Randomise()));
         } else {
             arrow.setVelocity(loc.getDirection().multiply(velocity));
         }
         arrow.setMetadata("isPotionProj", SiegeEnginesUtil.addMetaDataValue("true"));
         Bukkit.getServer().getPluginManager().callEvent(new org.bukkit.event.entity.ProjectileLaunchEvent(arrow));
-        ItemStack itemStack = new ItemStack(Material.SPLASH_POTION);
+        ItemStack itemStack = this.getAmmuinitionItem();
         PotionMeta potionMeta = (PotionMeta) itemStack.getItemMeta();
-        potionMeta.addCustomEffect(new PotionEffect(PotionEffectType.HARM, 100, 3, true), true);
+        System.out.println(potionMeta.toString());
+        System.out.println(itemStack.toString());
+        potionMeta.getBasePotionData();
         itemStack.setItemMeta(potionMeta);
         ThrownPotion potion = (ThrownPotion) arrow;
         potion.setItem(itemStack);
-        world.playSound(loc, this.SoundType, 20, 2);
-        world.spawnParticle(this.ParticleType, loc.getX(), loc.getY(), loc.getZ(), 0);
+        world.playSound(loc, this.soundType, 20, 2);
+        world.spawnParticle(this.particleType, loc.getX(), loc.getY(), loc.getZ(), 0);
     }
 
     private Vector Randomise() {
-        return new Vector(SiegeEngines.random.nextFloat() * (Inaccuracy - (Inaccuracy * -1)) + (Inaccuracy * -1), SiegeEngines.random.nextFloat() * (Inaccuracy - (Inaccuracy * -1)) + (Inaccuracy * -1), SiegeEngines.random.nextFloat() * (Inaccuracy - (Inaccuracy * -1)) + (Inaccuracy * -1));
+        return new Vector(SiegeEngines.random.nextFloat() * (inaccuracy - (inaccuracy * -1)) + (inaccuracy * -1), SiegeEngines.random.nextFloat() * (inaccuracy - (inaccuracy * -1)) + (inaccuracy * -1), SiegeEngines.random.nextFloat() * (inaccuracy - (inaccuracy * -1)) + (inaccuracy * -1));
     }
 
 	public ProjectileType getProjectileType() {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -108,6 +108,14 @@ Projectiles:
     EntityCount: 1
     VelocityFactor: 0.5
     Delay: 5
+  SplashPotionProjectile:
+    ProjectileType: POTION
+    Inaccuracy: 0.0125
+    EntityCount: 1
+    VelocityFactor: 0.5
+    ArrowDamageFactor: 1.0
+    AmmoItem: SPLASH_POTION
+    FireSound: ITEM_CROSSBOW_SHOOT
 
 SiegeEngines:
   Trebuchet:
@@ -134,6 +142,7 @@ SiegeEngines:
       - ScatterShot
       - DragonsBreath
       - FireworkShot
+      - SplashPotionProjectile
     ItemName: "&e&lBallista"
     Lore:
       - "&ePlace as a block to spawn a Ballista"


### PR DESCRIPTION
feat: Adds splash potions as a projectile for Ballistas. Any splash potion can be used and the projectile should match the color and effect of the potion loaded.